### PR TITLE
simplify compiled code

### DIFF
--- a/src/tmcn_encoding_isbig5.cpp
+++ b/src/tmcn_encoding_isbig5.cpp
@@ -22,7 +22,7 @@ int IsBIG5(const void* pBuffer, long size)
 			if (start >= end -1)
 				break;
  
-			if (start[1] < 0X40 || start[1] > 0X7E && start[1] < 0XA1 || start[1] > 0xFE)
+			if (start[1] < 0X40 || (start[1] > 0X7E && start[1] < 0XA1) || start[1] > 0xFE)
 			{
 				IsBIG5 = 0;
 				break;
@@ -40,7 +40,7 @@ int IsBIG5(const void* pBuffer, long size)
 			if (start >= end -1)
 				break;
  
-			if (start[1] < 0X40 || start[1] > 0X7E && start[1] < 0XA1 || start[1] > 0xFE)
+			if (start[1] < 0X40 || (start[1] > 0X7E && start[1] < 0XA1) || start[1] > 0xFE)
 			{
 				IsBIG5 = 0;
 				break;
@@ -62,10 +62,7 @@ int IsBIG5(const void* pBuffer, long size)
 extern "C" {
 	void CWrapper_encoding_isbig5(char **characters, int *numres)
 	{
-		char* s = *characters;
-		int l;
-		l = strlen(s);
-		*numres = IsBIG5(s,l);
+		*numres = IsBIG5(*characters, strlen(*characters));
 	}
 }
 

--- a/src/tmcn_encoding_isgb18030.cpp
+++ b/src/tmcn_encoding_isgb18030.cpp
@@ -150,10 +150,7 @@ int IsGB18030(const void* pBuffer, long size)
 extern "C" {
 	void CWrapper_encoding_isgb18030(char **characters, int *numres)
 	{
-		char* s = *characters;
-		int l;
-		l = strlen(s);
-		*numres = IsGB18030(s,l);
+		*numres = IsGB18030(*characters,strlen(*characters));
 	}
 }
 

--- a/src/tmcn_encoding_isgb2312.cpp
+++ b/src/tmcn_encoding_isgb2312.cpp
@@ -62,10 +62,7 @@ int IsGB2312(const void* pBuffer, long size)
 extern "C" {
 	void CWrapper_encoding_isgb2312(char **characters, int *numres)
 	{
-		char* s = *characters;
-		int l;
-		l = strlen(s);
-		*numres = IsGB2312(s,l);
+	  *numres = IsGB2312(*characters,strlen(*characters));
 	}
 }
 

--- a/src/tmcn_encoding_isgbk.cpp
+++ b/src/tmcn_encoding_isgbk.cpp
@@ -108,10 +108,7 @@ int IsGBK(const void* pBuffer, long size)
 extern "C" {
 	void CWrapper_encoding_isgbk(char **characters, int *numres)
 	{
-		char* s = *characters;
-		int l;
-		l = strlen(s);
-		*numres = IsGBK(s,l);
+	  *numres = IsGBK(*characters,strlen(*characters));
 	}
 }
 

--- a/src/tmcn_encoding_isutf8.cpp
+++ b/src/tmcn_encoding_isutf8.cpp
@@ -51,10 +51,7 @@ int IsUTF8(const void* pBuffer, long size) {
 extern "C" {
 	void CWrapper_encoding_isutf8(char **characters, int *numres)
 	{
-		char* s = *characters;
-		int l;
-		l = strlen(s);
-		*numres = IsUTF8(s,l);
+	  *numres = IsUTF8(*characters,strlen(*characters));
 	}
 }
 


### PR DESCRIPTION
This simplifies the compiled code somewhat, specifically:
1. Solves for a couple of warnings about ambiguous conditionals;
2. Rather than reassigning values to new variables within the Cwrapper_\* functions, relies on the underlying values without any assigment (as an aside, int x; int x = foo(); is usually the wrong approach to code - try int x = foo();. Allocation and assignment are handled in one step rather than two, which makes a speed difference).
